### PR TITLE
Returning data to calculate attempts for recovering account. Fixes

### DIFF
--- a/routes/reset.js
+++ b/routes/reset.js
@@ -60,10 +60,8 @@ module.exports = {
     // release any pressue on backoff
     .then(function() {
       var ip = request.info.remoteAddress;
-      var path = '/api/recover/{query}';
-      var method = 'POST';
       var pressureRelease = request.server.plugins.backoff.release;
-      return pressureRelease(request.db.db, ip, path, method);
+      return pressureRelease(request.db.db, ip);
     })
     .then(function() {
       // TODO: Send password reset confirmation email here


### PR DESCRIPTION
NOTE: UPDATE NPM VERSION FOR THIS TO TAKE EFFECT IN PRODUCTION @wangbus 

* Fix to clear out recover attempts once password is successfully reset

* Sending data to calculate failed attempts to display on the account
  recovery page.